### PR TITLE
Enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Normalize text line endings to LF in this repository.
+* text=auto eol=lf
+
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.jpeg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Adds a repository-level .gitattributes LF policy and normalizes tracked text files from CRLF to LF. Binary and Git LFS files marked as binary remain governed by their existing attributes.